### PR TITLE
[fix-org-branch] Create orgs from latest task branch, not default repo branch.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -177,10 +177,6 @@ Docker container, omit any ``docker-compose run --rm web...`` prefix, e.g.::
 After running ``yarn serve``, view the running app at
 `<http://localhost:8080/>`_ in your browser.
 
-To view logs from other Docker containers (e.g. redis or postgres), run the
-"Docker Containers: View Logs" command from the VS Code Command Palette and
-select the desired container.
-
 For more detailed instructions and options, see the `VS Code documentation`_.
 
 .. _VS Code: https://code.visualstudio.com/

--- a/metashare/api/tests/jobs.py
+++ b/metashare/api/tests/jobs.py
@@ -26,6 +26,7 @@ class TestCreateBranchesOnGitHub:
         task = task_factory()
         project = task.project
         with ExitStack() as stack:
+            stack.enter_context(patch(f"{PATCH_ROOT}.local_github_checkout"))
             global_config = stack.enter_context(patch("metashare.api.gh.GlobalConfig"))
             global_config_instance = MagicMock()
             global_config.return_value = global_config_instance
@@ -43,7 +44,6 @@ class TestCreateBranchesOnGitHub:
                 repo_url="https://github.com/user/repo-bohemia",
                 project=project,
                 task=task,
-                repo_root="",
             )
 
             assert repository.create_branch_ref.called
@@ -72,7 +72,6 @@ class TestCreateBranchesOnGitHub:
                 repo_url="https://github.com/user/repo-francia",
                 project=project,
                 task=task,
-                repo_root="",
             )
 
             assert not repository.create_branch_ref.called


### PR DESCRIPTION
## Cute animal pic
_Because everyone likes pictures of animals._

![bluebird](http://blogs.tallahassee.com/community/wp-content/uploads/2015/01/Bluebird.jpg)

## Link to Trello card (if applicable)
_If this PR relates to a Trello card, don't forget to reference this PR on the card as well._

N/A

## Description
_The commit messages say what you did; this should explain why and how._

This resolves a bug where new scratch orgs were being provisioned from (and flows run on) the default repo branch instead of the latest task branch. See explanation in https://oddbird.slack.com/archives/CB2576XT4/p1571327862114600?thread_ts=1571182294.098200&cid=CB2576XT4

## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally._

1. Create Dev scratch org. It should show "Status: up-to-date"
2. Click "View Org" to open the org.
3. Click the "Object Manager" tab.
4. Click "Contact"
5. Click "Fields & Relationships" on the left.
6. Click the "New" button.
7. Choose "Text" and click the "Next" button.
8. Enter a Field Label (e.g. "Favorite Color") and Length. Click the "Next" button.
9. Deselect all profiles in the Visible column except for System Administrator (not required, but it'll make for less noise in the changes). Click the "Next" button.
10. Deselect all page layouts except for "Contact Layout" (not required). Click the "Save" button.
11. Return to MetaShare and click "check again". It should show 3 uncaptured changes.
12. Click the Capture Task Changes button.
13. Select the field and layout but not the profile. Add a commit message and click the button to capture.
14. The Dev card should show the new commit and one uncaptured change (the profile)
15. Looking at the new commit, the modified files should be src/layouts/Contact-Contact Layout.layout, src/objects/Contact.object, and src/package.xml
16. Create a new QA org. It should successfully end up with the new field on the Contact object. 

*BUT*... step 16 still doesn't quite work. With these changes it now does attempt to create the org and run the flow from the latest task branch, but errors with the following: https://pastebin.com/8xjAADeA

I think this could be merged anyway as an improvement.

Unfortunately this error happens during the flow run, which means it has actually been created, and on error it is deleted in MS but not actually deleted on the SF side of things. (Creating a new bug story for that: https://trello.com/c/p4gpRNcC.)

---

## Reviewer tasks:

- [x] Pulled branch and ran code locally (or viewed on preview deployment, if applicable)
- [x] Reproduced the issue to review in the browser
- [x] Reviewed code
