### PR TITLE
[no-empty-repos-list] No need to refresh repos list after WS disconnect/reconnect.

### DIFF
--- a/src/js/store/repositories/reducer.ts
+++ b/src/js/store/repositories/reducer.ts
@@ -1,6 +1,6 @@
 import { ObjectsAction, PaginatedObjectResponse } from '@/store/actions';
 import { RepositoriesAction } from '@/store/repositories/actions';
-import { LogoutAction, RefetchDataAction } from '@/store/user/actions';
+import { LogoutAction } from '@/store/user/actions';
 import { OBJECT_TYPES } from '@/utils/constants';
 
 export interface Repository {
@@ -28,10 +28,9 @@ const defaultState = {
 
 const reducer = (
   repositories: RepositoriesState = defaultState,
-  action: RepositoriesAction | ObjectsAction | LogoutAction | RefetchDataAction,
+  action: RepositoriesAction | ObjectsAction | LogoutAction,
 ): RepositoriesState => {
   switch (action.type) {
-    case 'REFETCH_DATA_SUCCEEDED':
     case 'USER_LOGGED_OUT':
       return { ...defaultState };
     case 'REFRESH_REPOS_REQUESTED':

--- a/test/js/store/repositories/reducer.test.js
+++ b/test/js/store/repositories/reducer.test.js
@@ -13,7 +13,7 @@ describe('reducer', () => {
     expect(actual).toEqual(expected);
   });
 
-  test.each([['USER_LOGGED_OUT'], ['REFETCH_DATA_SUCCEEDED']])(
+  test.each([['USER_LOGGED_OUT']])(
     'returns initial state on %s action',
     (action) => {
       const repository1 = {


### PR DESCRIPTION
## Cute animal pic
_Because everyone likes pictures of animals._

![hawk](https://www.catersnews.com/wp-content/uploads/2014/12/4_MPM-Photobombed_hawk_5.jpg)

## Link to Trello card (if applicable)
_If this PR relates to a Trello card, don't forget to reference this PR on the card as well._

https://trello.com/c/ROtqxOLK

## Description
_The commit messages say what you did; this should explain why and how._

For most objects in the front end store, we want to wipe and force a refetch after the WS channel disconnects/reconnects. This ensures that any models are up-to-date, and that the new WS channel subscribes to the models appropriately.

For repositories this was overkill, both because it was not properly refetching them anyway, and also because they seldom change and we do not subscribe to them via WS.

## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally._

- Run the django server and webpack server in separate processes (e.g. `yarn webpack:serve` in one terminal and `yarn django:serve` in another)
- Go to the main repos list (http://localhost:8080/repositories)
- Shut down the django server for 5 seconds and then restart
- Your repos are still there.

---

## Reviewer tasks:

- [ ] Pulled branch and ran code locally
- [ ] Reproduced the issue to review in the browser
- [ ] Reviewed code
- [ ] Updated Trello card (if applicable)
