### PR TITLE
[well-named-errors] Report name errors as coming from the name field.

### DIFF
--- a/metashare/api/serializers.py
+++ b/metashare/api/serializers.py
@@ -11,6 +11,23 @@ from .validators import CaseInsensitiveUniqueTogetherValidator
 User = get_user_model()
 
 
+class FormattableDict:
+    """
+    Stupid hack to get a dict error message into a
+    CaseInsensitiveUniqueTogetherValidator, so the error can be assigned
+    to a particular key.
+    """
+
+    def __init__(self, key, msg):
+        self.key = key
+        self.msg = msg
+
+    def format(self, *args, **kwargs):
+        return {
+            self.key: self.msg.format(*args, **kwargs),
+        }
+
+
 class HashidPrimaryKeyRelatedField(serializers.PrimaryKeyRelatedField):
     def to_representation(self, value):
         if self.pk_field is not None:
@@ -89,7 +106,9 @@ class ProjectSerializer(serializers.ModelSerializer):
             CaseInsensitiveUniqueTogetherValidator(
                 queryset=Project.objects.all(),
                 fields=("name", "repository"),
-                message=_("A project with this name already exists."),
+                message=FormattableDict(
+                    "name", _("A project with this name already exists.")
+                ),
             ),
         )
 
@@ -130,7 +149,9 @@ class TaskSerializer(serializers.ModelSerializer):
             CaseInsensitiveUniqueTogetherValidator(
                 queryset=Task.objects.all(),
                 fields=("name", "project"),
-                message=_("A task with this name already exists."),
+                message=FormattableDict(
+                    "name", _("A task with this name already exists.")
+                ),
             ),
         )
 

--- a/metashare/api/tests/serializers.py
+++ b/metashare/api/tests/serializers.py
@@ -84,7 +84,7 @@ class TestProjectSerializer:
             }
         )
         assert not serializer.is_valid()
-        assert [str(err) for err in serializer.errors["non_field_errors"]] == [
+        assert [str(err) for err in serializer.errors["name"]] == [
             "A project with this name already exists."
         ]
 
@@ -101,7 +101,7 @@ class TestProjectSerializer:
             }
         )
         assert not serializer.is_valid()
-        assert [str(err) for err in serializer.errors["non_field_errors"]] == [
+        assert [str(err) for err in serializer.errors["name"]] == [
             "A project with this name already exists."
         ]
 


### PR DESCRIPTION
I found a stupid-hack way to get the error messages onto the right field. It's surprisingly low-impact!

![catte](https://static.boredpanda.com/blog/wp-content/uploads/2019/10/norwegian-forest-cats-sampy-hiskias-59-5db800bdc135d__700.jpg)