### PR TITLE
[fix-backend-gettext] Use more string literals for user-facing errors

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -205,4 +205,10 @@ automatically parsed, but will log errors while the app is running if they're
 missing from the served translation files. To resolve, add the missing key:value
 translations to ``locales/<language>/translation.json``.
 
+This applies to the server code too, except no error will be raised.
+Therefore, you should use string literals everywhere in server-side code
+that might be exposed to the frontend, to properly generate translation
+files. See error message handling in ``metashare/api/sf_run_flow.py``
+for an example.
+
 .. _user language is auto-detected at runtime: https://github.com/i18next/i18next-browser-languageDetector

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -205,10 +205,9 @@ automatically parsed, but will log errors while the app is running if they're
 missing from the served translation files. To resolve, add the missing key:value
 translations to ``locales/<language>/translation.json``.
 
-This applies to the server code too, except no error will be raised.
-Therefore, you should use string literals everywhere in server-side code
-that might be exposed to the frontend, to properly generate translation
-files. See error message handling in ``metashare/api/sf_run_flow.py``
-for an example.
+This applies to the server code too, except no error will be raised. Therefore,
+you should use string literals everywhere in server-side code that might be
+exposed to the front end, to properly generate translation files. See error
+message handling in ``metashare/api/sf_run_flow.py`` for an example.
 
 .. _user language is auto-detected at runtime: https://github.com/i18next/i18next-browser-languageDetector

--- a/metashare/api/sf_run_flow.py
+++ b/metashare/api/sf_run_flow.py
@@ -64,23 +64,20 @@ def refresh_access_token(*, config, org_name, scratch_org):
         org_config.config["access_token"] = info["access_token"]
         return org_config
     except HTTPError as err:
-        error_msg = _("Are you certain that the org still exists?")
-
         if get_current_job():
             job_id = get_current_job().id
+            # This error is user-facing, and so for makemessages to
+            # pick it up correctly, we need it to be a single,
+            # unbroken, string literal (even though adjacent string
+            # literals should be parsed by the AST into a single
+            # string literal and picked up by makemessages, but
+            # that's a gripe for another day). We have relatively
+            # few errors that propagate directly from the backend
+            # like this, but when we do, this is the pattern we
+            # should use.
+            #
+            # This is also why we repeat the first sentence.
             error_msg = _(
-                # This error is user-facing, and so for makemessages to
-                # pick it up correctly, we need it to be a single,
-                # unbroken, string literal (even though adjacent string
-                # literals should be parsed by the AST into a single
-                # string literal and picked up by makemessages, but
-                # that's a gripe for another day). We have relatively
-                # few errors that propagate directly from the backend
-                # like this, but when we do, this is the pattern we
-                # should use.
-                #
-                # This is also why we repeat the first sentence in three
-                # places.
                 f"Are you certain that the org still exists? If you need support, your job ID is {job_id}."  # noqa: E501
             )
         else:

--- a/metashare/api/sf_run_flow.py
+++ b/metashare/api/sf_run_flow.py
@@ -64,15 +64,29 @@ def refresh_access_token(*, config, org_name, scratch_org):
         org_config.config["access_token"] = info["access_token"]
         return org_config
     except HTTPError as err:
-        error_msg = "Are you certain that the org still exists?"
+        error_msg = _("Are you certain that the org still exists?")
 
         if get_current_job():
             job_id = get_current_job().id
-            error_msg += f" If you need support, your job ID is {job_id}."
+            error_msg = _(
+                # This error is user-facing, and so for makemessages to
+                # pick it up correctly, we need it to be a single,
+                # unbroken, string literal (even though adjacent string
+                # literals should be parsed by the AST into a single
+                # string literal and picked up by makemessages, but
+                # that's a gripe for another day). We have relatively
+                # few errors that propagate directly from the backend
+                # like this, but when we do, this is the pattern we
+                # should use.
+                #
+                # This is also why we repeat the first sentence in three
+                # places.
+                f"Are you certain that the org still exists? If you need support, your job ID is {job_id}."  # noqa: E501
+            )
         else:
-            error_msg += f" {err.args[0]}"
+            error_msg = _(f"Are you certain that the org still exists? {err.args[0]}")
 
-        err = err.__class__(_(error_msg), *err.args[1:],)
+        err = err.__class__(error_msg, *err.args[1:],)
         scratch_org.remove_scratch_org(err)
         raise err
 


### PR DESCRIPTION
This is in aid of getting makemessages to gather them correctly. It cannot see anything but single string literals inside gettext calls.

I would love another set of eyes to make sure I'm not missing other backend-generated user-facing errors we should be able to translate.

![cats](https://static.boredpanda.com/blog/wp-content/uploads/2019/10/norwegian-forest-cats-sampy-hiskias-60-5db800bf9315b__700.jpg)