### PR TITLE
Suppress sync warnings in Django restart

### DIFF
--- a/compose/web/start-server.sh
+++ b/compose/web/start-server.sh
@@ -4,7 +4,7 @@ if [ -z ${PORT+x} ];
 then
     # PORT unset, we presume this is local dev:
     python manage.py migrate
-    DJANGO_ALLOW_ASYNC_UNSAFE=true yarn serve
+    yarn serve
 else
     # PORT set, we presume this is Heroku:
     yarn django:serve:prod

--- a/compose/web/start-server.sh
+++ b/compose/web/start-server.sh
@@ -4,7 +4,7 @@ if [ -z ${PORT+x} ];
 then
     # PORT unset, we presume this is local dev:
     python manage.py migrate
-    yarn serve
+    DJANGO_ALLOW_ASYNC_UNSAFE=true yarn serve
 else
     # PORT set, we presume this is Heroku:
     yarn django:serve:prod

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -95,6 +95,9 @@ DEBUG = env("DJANGO_DEBUG", default=False, type_=boolish)
 
 MODE = env("DJANGO_MODE", default="dev" if DEBUG else "prod")
 
+if MODE == "dev":
+    environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
+
 ALLOWED_HOSTS = [
     "127.0.0.1",
     "127.0.0.1:8000",


### PR DESCRIPTION
This is a stop-gap measure to allow automatically restarting the server in development. In production, we don't have this issue, so that's good.  The error appeared to be arising not directly from any code we had written, and I had no luck isolating it to one component (Sentry, New Relic, the websocket consumer, and possibly other components were all candidates), so I opted to suppress the warning and allow restart in dev, instead.

Also, incidentally, I think we can drop the branch-name in PR title thing? GitHub has made the branch name a bit more visible and accessible since we started that, so I think it doesn't matter as much anymore, for me at least.