### PR TITLE
[improve-hook-reliability] Require reuse-running containers to be connectable

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -12,7 +12,10 @@ Cloning the project
 Docker-based development
 ------------------------
 
-1. Install `Docker Desktop (Community Edition)`_ and make sure it is running.
+1. Install `Docker Desktop (Community Edition)`_ and make sure it is
+   running. Ensure you're running ``docker-compose`` at least version
+   ``1.25.2`` to avoid container-abort bugs. The latest Docker Desktop
+   should come with this version or later.
 
 2. Create an ``.env`` file with the required environment variables::
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -7,7 +7,7 @@ SERVICE_NAME=web
 STARTED_BACKGROUND_CONTAINER=0
 
 function is_running {
-    RUNNING=`docker-compose top $SERVICE_NAME`
+    RUNNING=`docker-compose top $SERVICE_NAME | grep "$SERVICE_NAME"_1`
     if [[ -n "$RUNNING" ]]; then
         echo "running"
     else

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/SFDO-Tooling/MetaShare.git"
   },
   "engines": {
-    "node": "12.13.0"
+    "node": "12.14.1"
   },
   "scripts": {
     "webpack:serve": "webpack-dev-server --config webpack.dev.js",


### PR DESCRIPTION
The key thing here is to install the latest Docker Desktop, so you'll have `docker-compose` at least version `1.25.2`. There are a few small related tweaks in here.

![cats](https://static.boredpanda.com/blog/wp-content/uploads/2019/10/norwegian-forest-cats-sampy-hiskias-8-5db80045470fd__700.jpg)