### PR TITLE
force wrapping on nested cards

### DIFF
--- a/src/js/components/tasks/cards/card.tsx
+++ b/src/js/components/tasks/cards/card.tsx
@@ -209,7 +209,7 @@ const OrgCard = ({
           <>
             <hr className="slds-m-vertical_none" />
             <Card
-              className="nested-card"
+              className="nested-card wrap-inner-truncate"
               heading={orgHeading}
               icon={
                 org &&

--- a/src/js/components/tasks/cards/orgActions.tsx
+++ b/src/js/components/tasks/cards/orgActions.tsx
@@ -94,7 +94,7 @@ const OrgActions = ({
         <Button
           label={i18n.t('Submit Review')}
           variant="outline-brand"
-          className="slds-m-right_small"
+          className="slds-m-right_x-small"
           onClick={openSubmitReviewModal}
         />
       );
@@ -110,7 +110,7 @@ const OrgActions = ({
             <Button
               label={i18n.t('Submit Review')}
               variant="outline-brand"
-              className="slds-m-right_small"
+              className="slds-m-right_x-small"
               disabled
             />
           </Tooltip>
@@ -126,7 +126,7 @@ const OrgActions = ({
           <Button
             label={i18n.t('Refresh Org')}
             variant="brand"
-            className="slds-m-right_small"
+            className="slds-m-right_x-small"
             onClick={doRefreshOrg}
           />
         )}

--- a/src/js/components/tasks/cards/orgActions.tsx
+++ b/src/js/components/tasks/cards/orgActions.tsx
@@ -85,7 +85,7 @@ const OrgActions = ({
         <Button
           label={i18n.t('Update Review')}
           variant="outline-brand"
-          className="slds-m-right_small"
+          className="slds-m-right_x-small"
           onClick={openSubmitReviewModal}
         />
       );

--- a/src/js/components/tasks/cards/submitReview.tsx
+++ b/src/js/components/tasks/cards/submitReview.tsx
@@ -57,7 +57,7 @@ const SubmitReviewModal = ({
     fields: {
       notes: '',
       status: reviewStatus || REVIEW_STATUSES.APPROVED,
-      delete_org: true,
+      delete_org: Boolean(orgId),
     },
     url,
     additionalData: {
@@ -72,6 +72,11 @@ const SubmitReviewModal = ({
   useEffect(() => {
     setInputs({ ...inputs, status: reviewStatus || REVIEW_STATUSES.APPROVED });
   }, [reviewStatus]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // When orgId changes, update default selection
+  useEffect(() => {
+    setInputs({ ...inputs, delete_org: Boolean(orgId) });
+  }, [orgId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleSubmitClicked = () => {
     // Click hidden button inside form to activate native browser validation

--- a/src/sass/components/_org-cards.scss
+++ b/src/sass/components/_org-cards.scss
@@ -14,3 +14,14 @@
     padding-right: 0;
   }
 }
+
+// override min-width and force header to wrap on nested card headers
+.wrap-inner-truncate {
+  .slds-card__header {
+    flex-wrap: wrap;
+  }
+
+  .slds-has-flexi-truncate {
+    min-width: auto;
+  }
+}

--- a/src/sass/components/_org-cards.scss
+++ b/src/sass/components/_org-cards.scss
@@ -23,5 +23,6 @@
 
   .slds-has-flexi-truncate {
     min-width: auto;
+    margin-right: $spacing-x-small;
   }
 }


### PR DESCRIPTION
## Cute animal pic
_Because everyone likes pictures of animals._
![gary-bendig-6GMq7AGxNbE-unsplash](https://user-images.githubusercontent.com/1581694/74972051-b3106100-53e6-11ea-8b2a-627a1c074a82.jpg)



## Link to Trello card (if applicable)
_If this PR relates to a Trello card, don't forget to reference this PR on the card as well._

Was a part of this story: https://trello.com/c/BegMDQLo/58-facilitate-qa-results-submission-through-metashare-and-github-commit-status but waited until after merge to fix

## Description
_The commit messages say what you did; this should explain why and how._
- [ ] Description is in Trello card
Allowed the nested card to wrap instead of truncating the heading "Review Org"


## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally._
You can test once you, as the reviewer, has already submitted a review, then deleted the org. That is when 2 buttons will appear in the header of that Reviewer Card


## Impacted areas of website
_Provide URLs and/or a description of where to look._

Task detail page

## Show me
_Provide screenshots/animated gifs/videos if necessary._

![wraps-between 1000-1200ish](https://user-images.githubusercontent.com/1581694/74972421-477ac380-53e7-11ea-8bd8-b7ecd6c3d1f5.jpg)
![2-buttons-wrapping-allowed](https://user-images.githubusercontent.com/1581694/74972712-dab3f900-53e7-11ea-99ef-0063f85447fd.jpg)

There isn't a great way to add spacing between these two without effecting the things around it and since we can't easily edit the markup, it is probably best that for a small set of widths, we can overlook the fact that the buttons are close to the heading. The costs don't outweigh the benefit.

---

## Reviewer tasks:

- [ ] Reviewed code
- [ ] Reviewed screenshots