### PR TITLE
Avoid concurrent runs of refresh_repositories

### DIFF
--- a/metashare/api/models.py
+++ b/metashare/api/models.py
@@ -55,18 +55,32 @@ class User(HashIdMixin, AbstractUser):
     currently_fetching_repos = models.BooleanField(default=False)
     devhub_username = StringField(null=True, blank=True)
 
+    def queue_refresh_repositories(self):
+        """Queue a job to refresh repositories unless we're already doing so"""
+        from .jobs import refresh_github_repositories_for_user_job
+
+        if not self.currently_fetching_repos:
+            self.currently_fetching_repos = True
+            self.save()
+            refresh_github_repositories_for_user_job.delay(self)
+
     def refresh_repositories(self):
-        repos = gh.get_all_org_repos(self)
-        GitHubRepository.objects.filter(user=self).delete()
-        GitHubRepository.objects.bulk_create(
-            [
-                GitHubRepository(user=self, repo_id=repo.id, repo_url=repo.html_url)
-                for repo in repos
-            ]
-        )
-        self.currently_fetching_repos = False
-        self.save()
-        self.notify_repositories_updated()
+        try:
+            repos = gh.get_all_org_repos(self)
+            with transaction.atomic():
+                GitHubRepository.objects.filter(user=self).delete()
+                GitHubRepository.objects.bulk_create(
+                    [
+                        GitHubRepository(
+                            user=self, repo_id=repo.id, repo_url=repo.html_url
+                        )
+                        for repo in repos
+                    ]
+                )
+            self.notify_repositories_updated()
+        finally:
+            self.currently_fetching_repos = False
+            self.save()
 
     def notify_repositories_updated(self):
         message = {"type": "USER_REPOS_REFRESH"}
@@ -749,9 +763,7 @@ class ScratchOrg(PushMixin, HashIdMixin, TimestampsMixin, models.Model):
 
 @receiver(user_logged_in)
 def user_logged_in_handler(sender, *, user, **kwargs):
-    from .jobs import refresh_github_repositories_for_user_job
-
-    refresh_github_repositories_for_user_job.delay(user)
+    user.queue_refresh_repositories()
 
 
 def ensure_slug_handler(sender, *, created, instance, **kwargs):

--- a/metashare/api/templatetags/api_bootstrap.py
+++ b/metashare/api/templatetags/api_bootstrap.py
@@ -10,10 +10,6 @@ register = template.Library()
 
 @register.filter
 def serialize(user):
-    from ..jobs import refresh_github_repositories_for_user_job
-
     if not user.repositories.exists():
-        user.currently_fetching_repos = True
-        user.save()
-        refresh_github_repositories_for_user_job.delay(user)
+        user.queue_refresh_repositories()
     return escape(json.dumps(FullUserSerializer(user).data))

--- a/metashare/api/tests/models.py
+++ b/metashare/api/tests/models.py
@@ -609,7 +609,6 @@ class TestGitHubRepository:
 @pytest.mark.django_db
 def test_login_handler(user_factory):
     user = user_factory()
-    patch_path = "metashare.api.jobs.refresh_github_repositories_for_user_job"
-    with patch(patch_path) as refresh_job:
-        user_logged_in_handler(None, user=user)
-        refresh_job.delay.assert_called_with(user)
+    user.queue_refresh_repositories = MagicMock()
+    user_logged_in_handler(None, user=user)
+    user.queue_refresh_repositories.assert_called_once()

--- a/metashare/api/views.py
+++ b/metashare/api/views.py
@@ -94,10 +94,8 @@ class UserRefreshView(CurrentUserObjectMixin, APIView):
     permission_classes = (IsAuthenticated,)
 
     def post(self, request):
-        from .jobs import refresh_github_repositories_for_user_job
-
         user = self.get_object()
-        refresh_github_repositories_for_user_job.delay(user)
+        user.queue_refresh_repositories()
         return Response(status=status.HTTP_202_ACCEPTED)
 
 


### PR DESCRIPTION
We've occasionally gotten db integrity errors for GitHubRepository duplicates which I think may happen if multiple concurrent runs of user.refresh_repositories get triggered for the same user. This attempts to avoid queuing a refresh if one is already in progress.