### PR TITLE
📦 Re-lock Python; remove django-filters which is not the same as django-filter

### DIFF
--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -5,7 +5,6 @@ channels==2.4.0
 https://github.com/SFDO-Tooling/CumulusCI/archive/master.tar.gz
 dj-database-url==0.5.0
 django-allauth==0.41.0
-django-filters==0.2.1
 django-hashid-field==3.1.1
 django-js-reverse==0.9.1
 django-log-request-id==1.4.1
@@ -22,6 +21,6 @@ psycopg2-binary==2.8.4
 sentry-sdk==0.14.2
 service_identity==18.1.0
 https://github.com/SFDO-Tooling/sfdo-template-helpers/archive/master.tar.gz
-simple-salesforce==0.74.2
+simple-salesforce==0.75.3
 whitenoise==5.0.1
 django-anymail[mailgun]==7.0.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -6,27 +6,30 @@
 #
 aioredis==1.3.0           # via channels-redis
 asgiref==3.2.2            # via channels, channels-redis, daphne, django
+asn1crypto==1.3.0         # via cumulusci
 async-timeout==3.0.1      # via aioredis
 attrs==19.3.0             # via automat, service-identity, twisted
+authlib==0.14.1           # via simple-salesforce
 autobahn==19.10.1         # via daphne
 automat==0.7.0            # via twisted
 bleach==3.1.1             # via -r requirements/prod.in, sfdo-template-helpers
-certifi==2019.11.28       # via requests, sentry-sdk
-cffi==1.14.0              # via cryptography
+certifi==2019.11.28       # via cumulusci, requests, sentry-sdk
+cffi==1.14.0              # via cryptography, cumulusci
 channels-redis==2.4.2     # via -r requirements/prod.in
 channels==2.4.0           # via -r requirements/prod.in, channels-redis
-chardet==3.0.4            # via requests
-click==7.0                # via rq
+chardet==3.0.4            # via cumulusci, requests
+click==7.0                # via cumulusci, rq
+coloredlogs==14.0         # via cumulusci
 constantly==15.1.0        # via twisted
 croniter==0.3.31          # via rq-scheduler
-cryptography==2.8         # via autobahn, jwcrypto, pyopenssl, requests, service-identity, sfdo-template-helpers
+cryptography==2.8         # via authlib, autobahn, cumulusci, jwcrypto, pyopenssl, requests, secretstorage, service-identity, sfdo-template-helpers
+https://github.com/SFDO-Tooling/CumulusCI/archive/master.tar.gz  # via -r requirements/prod.in
 daphne==2.3.0             # via channels
 defusedxml==0.6.0         # via python3-openid
 dj-database-url==0.5.0    # via -r requirements/prod.in
 django-allauth==0.41.0    # via -r requirements/prod.in
 django-anymail[mailgun]==7.0.0  # via -r requirements/prod.in
 django-filter==2.2.0      # via sfdo-template-helpers
-django-filters==0.2.1     # via -r requirements/prod.in
 django-hashid-field==3.1.1  # via -r requirements/prod.in
 django-js-reverse==0.9.1  # via -r requirements/prod.in
 django-log-request-id==1.4.1  # via -r requirements/prod.in
@@ -35,46 +38,72 @@ django-redis==4.11.0      # via -r requirements/prod.in
 django-rq==2.3.0          # via -r requirements/prod.in
 django==3.0.4             # via -r requirements/prod.in, channels, django-allauth, django-anymail, django-filter, django-hashid-field, django-js-reverse, django-log-request-id, django-model-utils, django-redis, django-rq, djangorestframework, sfdo-template-helpers
 djangorestframework==3.11.0  # via -r requirements/prod.in, sfdo-template-helpers
+docutils==0.16            # via cumulusci
+factory-boy==2.12.0       # via cumulusci
+faker==4.0.1              # via factory-boy
 furl==2.1.0               # via -r requirements/prod.in
 github3-py==1.3.0         # via -r requirements/prod.in
+github3.py==1.3.0         # via cumulusci
 hashids==1.2.0            # via django-hashid-field
 hiredis==1.0.0            # via aioredis
+humanfriendly==7.1.1      # via coloredlogs, cumulusci
 hyperlink==19.0.0         # via twisted
 idna==2.8                 # via hyperlink, requests
 incremental==17.5.0       # via twisted
-jwcrypto==0.7             # via github3-py
+jeepney==0.4.3            # via keyring, secretstorage
+jinja2==2.11.1            # via cumulusci
+jwcrypto==0.7             # via cumulusci, github3-py, github3.py
+keyring==21.1.0           # via cumulusci
 logfmt==0.4               # via -r requirements/prod.in, sfdo-template-helpers
+lxml==4.5.0               # via cumulusci
 markdown==3.2.1           # via -r requirements/prod.in, sfdo-template-helpers
+markupsafe==1.1.1         # via cumulusci, jinja2
 msgpack==0.6.2            # via channels-redis
 oauthlib==3.1.0           # via requests-oauthlib
 orderedmultidict==1.0.1   # via furl
 psycopg2-binary==2.8.4    # via -r requirements/prod.in
 pyasn1-modules==0.2.8     # via service-identity
 pyasn1==0.4.8             # via pyasn1-modules, service-identity
-pycparser==2.19           # via cffi
+pycparser==2.19           # via cffi, cumulusci
+pydantic==1.4             # via cumulusci
 pyhamcrest==1.9.0         # via twisted
+pyjwt==1.7.1              # via cumulusci
 pyopenssl==19.1.0         # via requests
-python-dateutil==2.8.1    # via croniter, github3-py
+python-dateutil==2.8.1    # via croniter, cumulusci, faker, github3-py, github3.py
 python3-openid==3.1.0     # via django-allauth
-pytz==2019.3              # via django
+pytz==2019.3              # via cumulusci, django
+pyyaml==5.3               # via cumulusci
+raven==6.10.0             # via cumulusci
 redis==3.3.11             # via django-redis, django-rq, rq
 requests-oauthlib==1.2.0  # via django-allauth
-requests[security]==2.23.0  # via django-allauth, django-anymail, github3-py, requests-oauthlib, simple-salesforce
+requests[security]==2.23.0  # via cumulusci, django-allauth, django-anymail, github3-py, github3.py, requests-oauthlib, salesforce-bulk, simple-salesforce
+robotframework-lint==1.0  # via cumulusci
+robotframework-seleniumlibrary==4.3.0  # via cumulusci
+robotframework==3.1.2     # via cumulusci, robotframework-lint, robotframework-seleniumlibrary
 rq-scheduler==0.9.1       # via -r requirements/prod.in
 rq==1.2.2                 # via django-rq, rq-scheduler
+rst2ansi==0.1.5           # via cumulusci
+salesforce-bulk==2.1.0    # via cumulusci
+sarge==0.1.5.post0        # via cumulusci
+secretstorage==3.1.2      # via keyring
+selenium==3.141.0         # via cumulusci, robotframework-seleniumlibrary
 sentry-sdk==0.14.2        # via -r requirements/prod.in
 service_identity==18.1.0  # via -r requirements/prod.in
-https://github.com/SFDO-Tooling/CumulusCI/archive/master.tar.gz  # via -r requirements/prod.in
 https://github.com/SFDO-Tooling/sfdo-template-helpers/archive/master.tar.gz  # via -r requirements/prod.in
-simple-salesforce==0.74.2  # via -r requirements/prod.in
-six==1.14.0               # via autobahn, automat, bleach, cryptography, django-anymail, furl, orderedmultidict, pyhamcrest, pyopenssl, python-dateutil, txaio
+simple-salesforce==0.75.3  # via -r requirements/prod.in, cumulusci, salesforce-bulk
+six==1.14.0               # via autobahn, automat, bleach, cryptography, cumulusci, django-anymail, furl, orderedmultidict, pyhamcrest, pyopenssl, python-dateutil, salesforce-bulk, txaio
+sqlalchemy==1.3.13        # via cumulusci
 sqlparse==0.3.0           # via django
+terminaltables==3.1.0     # via cumulusci
+text-unidecode==1.3       # via faker
 twisted==19.7.0           # via daphne
 txaio==18.8.1             # via autobahn
-uritemplate==3.0.1        # via github3-py
-urllib3==1.25.8           # via requests, sentry-sdk
+unicodecsv==0.14.1        # via cumulusci, salesforce-bulk
+uritemplate==3.0.1        # via cumulusci, github3-py, github3.py
+urllib3==1.25.8           # via cumulusci, requests, selenium, sentry-sdk
 webencodings==0.5.1       # via bleach
 whitenoise==5.0.1         # via -r requirements/prod.in
+xmltodict==0.12.0         # via cumulusci
 zope.interface==4.6.0     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
The main point of this is to remove the unused requirement of django-filters

The other changes are from the update to cumulusci; I'm not sure why some of its dependencies were missing from the lockfile before.