### PR TITLE
Promote superusers by username rather than email

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -113,7 +113,7 @@ First log in using your GitHub account.
 
 Then turn this user into a superuser using the ``promote_superuser`` command::
 
-    $ docker-compose run --rm web python manage.py promote_superuser <your email>
+    $ docker-compose run --rm web python manage.py promote_superuser <username>
 
 You will also need, when you log in, to make sure that the GitHub app
 that provides MetaShare with webhook updates and GitHub API access **is
@@ -233,7 +233,7 @@ commands (this terminal runs inside the Docker container)::
 For any commands, when using the VS Code integrated terminal inside the
 Docker container, omit any ``docker-compose run --rm web...`` prefix, e.g.::
 
-    $ python manage.py promote_superuser <your email>
+    $ python manage.py promote_superuser <username>
     $ yarn test:js
     $ python manage.py truncate_data
     $ python manage.py populate_data

--- a/metashare/management/commands/promote_superuser.py
+++ b/metashare/management/commands/promote_superuser.py
@@ -8,13 +8,13 @@ class Command(BaseCommand):
     help = "Promotes a user to superuser status."
 
     def add_arguments(self, parser):
-        parser.add_argument("emails", nargs="+")
+        parser.add_argument("usernames", nargs="+")
 
     def handle(self, *args, **options):
-        num = User.objects.filter(email__in=options["emails"]).update(
+        num = User.objects.filter(username__in=options["usernames"]).update(
             is_superuser=True, is_staff=True
         )
         if num:
             self.stdout.write(self.style.SUCCESS("Promoted!"))
         else:
-            self.stdout.write(self.style.ERROR("No such email(s)."))
+            self.stdout.write(self.style.ERROR("No such username(s)."))

--- a/metashare/management/commands/tests/promote_superuser.py
+++ b/metashare/management/commands/tests/promote_superuser.py
@@ -9,12 +9,12 @@ def test_promote_superuser__no_such_user():
     out = StringIO()
     call_command("promote_superuser", "test@example.com", stdout=out)
 
-    assert "No such email(s)." in out.getvalue()
+    assert "No such username(s)." in out.getvalue()
 
 
 @pytest.mark.django_db
 def test_promote_superuser__success(user_factory):
-    user = user_factory(email="test@example.com")
+    user = user_factory(username="test@example.com")
     out = StringIO()
     call_command("promote_superuser", "test@example.com", stdout=out)
     user.refresh_from_db()


### PR DESCRIPTION
Like it says on the tin. It can be hard to remember which email from a github account is the default.