### PR TITLE
Add a Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,4 @@
+web: daphne --bind 0.0.0.0 --port $PORT metashare.asgi:application
+worker: python manage.py rqworker default
+worker-short: honcho start -f Procfile_worker_short
+release: python manage.py migrate --noinput

--- a/Procfile_worker_short
+++ b/Procfile_worker_short
@@ -1,2 +1,1 @@
-worker_short: python manage.py rqworker short
-scheduler: python manage.py rqscheduler --queue short
+scheduler: python manage.py rqscheduler

--- a/Procfile_worker_short
+++ b/Procfile_worker_short
@@ -1,0 +1,2 @@
+worker_short: python manage.py rqworker short
+scheduler: python manage.py rqscheduler --queue short

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "packtracker": "packtracker-upload --stats=webpack-stats.json --output-path=dist/prod",
     "build": "webpack --config webpack.dev.js",
     "prod": "webpack --config webpack.prod.js",
-    "prod:stats": "webpack --config webpack.prod.js --json > webpack-stats.json"
+    "prod:stats": "webpack --config webpack.prod.js --json > webpack-stats.json",
+    "heroku-postbuild": "yarn prod"
   },
   "dependencies": {
     "@salesforce-ux/design-system": "2.11.6",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+-r requirements/prod.txt

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -14,6 +14,7 @@ django-rq==2.3.0
 djangorestframework==3.11.0
 furl==2.1.0
 github3-py==1.3.0
+honcho==1.0.1
 rq-scheduler==0.9.1
 logfmt==0.4
 markdown==3.2.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -46,6 +46,7 @@ github3-py==1.3.0         # via -r requirements/prod.in
 github3.py==1.3.0         # via cumulusci
 hashids==1.2.0            # via django-hashid-field
 hiredis==1.0.0            # via aioredis
+honcho==1.0.1             # via -r requirements/prod.in
 humanfriendly==8.1        # via coloredlogs, cumulusci
 hyperlink==19.0.0         # via twisted
 idna==2.8                 # via hyperlink, requests


### PR DESCRIPTION
Add a Procfile to make it possible to do a non-container deployment to Heroku.

We've run some issues with the container stack:
- intermittent "blob not found" errors while pushing to the heroku container registry
- private space apps don't honor the `run` section of heroku.yml for some reason https://help.heroku.com/RNIC7H18/why-my-private-spaces-app-on-container-registry-runtime-ignores-heroku-yml
- it also seems to take longer to build using the Dockerfile